### PR TITLE
Vstretching=5 with ROMS source

### DIFF
--- a/pycnal/pycnal/grid.py
+++ b/pycnal/pycnal/grid.py
@@ -418,8 +418,6 @@ def get_ROMS_vgrid(gridid, zeta=None):
             vgrid = s_coordinate_2(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta)
         elif Vtrans == 4:
             vgrid = s_coordinate_4(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta) 
-    
-# jgp add
         elif Vtrans == 5:
             vgrid = s_coordinate_5(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta)
     

--- a/pycnal/pycnal/grid.py
+++ b/pycnal/pycnal/grid.py
@@ -107,7 +107,7 @@ class ROMS_gridinfo(object):
             line_nb = line_nb + 1
 
         if info == []:
-            raise ValueError('Unknow gridid. Please check your gridid.txt file')
+            raise ValueError('Unknown gridid. Please check your gridid.txt file')
 
         if info[4] == 'roms':
             self.name     =          info[1]
@@ -133,7 +133,7 @@ class ROMS_gridinfo(object):
             self.depth   = dep
 
         else:
-            raise ValueError('Unknow grid type. Please check your gridid.txt file')
+            raise ValueError('Unknown grid type. Please check your gridid.txt file')
 
       else: #lets get the grid information from the history and grid files
         #print 'CJMP> getting grid info from ROMS history and grid files'
@@ -417,9 +417,14 @@ def get_ROMS_vgrid(gridid, zeta=None):
         elif Vtrans == 2:
             vgrid = s_coordinate_2(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta)
         elif Vtrans == 4:
-            vgrid = s_coordinate_4(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta)
+            vgrid = s_coordinate_4(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta) 
+    
+# jgp add
+        elif Vtrans == 5:
+            vgrid = s_coordinate_5(h, theta_b, theta_s, Tcline, N, hraw=hraw, zeta=zeta)
+    
         else:
-            raise Warning('Unknow vertical transformation Vtrans')
+            raise Warning('Unknown vertical transformation Vtrans')
 
     elif  gridinfo.grdtype == 'z':
         N = gridinfo.N
@@ -427,7 +432,7 @@ def get_ROMS_vgrid(gridid, zeta=None):
         vgrid = z_coordinate(h, depth, N)
 
     else:
-        raise ValueError('Unknow grid type')
+        raise ValueError('Unknown grid type')
 
     return vgrid
 

--- a/pycnal/pycnal/vgrid.py
+++ b/pycnal/pycnal/vgrid.py
@@ -289,21 +289,25 @@ class s_coordinate_5(s_coordinate):
         self.z_r = z_r(self.h, self.hc, self.N, self.s_rho, self.Cs_r, self.zeta, self.Vtrans)
         self.z_w = z_w(self.h, self.hc, self.Np, self.s_w, self.Cs_w, self.zeta, self.Vtrans)
 
-
     def _get_s_rho(self):
-        lev = np.arange(1,self.N+1,1)
-        s = -(lev * lev - 2 * lev * self.N + lev + self.N * self.N - self.N) / \
-            (self.N * self.N - self.N) - \
-            0.01 * (lev * lev - lev * self.N) / (self.c1 - self.N)
-#            (self.c1 * self.N * self.N - self.N) - \
-        self.s_rho = s
+##        jgp replace
+#        lev = np.arange(1,self.N+1,1)
+#        s = -(lev * lev - 2 * lev * self.N + lev + self.N * self.N - self.N) / \
+#            (self.N * self.N - self.N) - \
+#            0.01 * (lev * lev - lev * self.N) / (self.c1 - self.N)
+#        self.s_rho = s
+##        jgp new section follows
+        lev = np.arange(1, self.N+1) - .5
+        self.s_rho = -(lev * lev - 2 * lev * self.N + lev + self.N * self.N - self.N) / \
+            (1.0 * self.N * self.N - self.N) - \
+            0.01 * (lev * lev - lev * self.N) / (1.0 - self.N)
+
 
     def _get_s_w(self):
         lev = np.arange(0,self.Np,1)
         s = -(lev * lev - 2 * lev * self.N + lev + self.N * self.N - self.N) / \
             (self.N * self.N - self.N) - \
             0.01 * (lev * lev - lev * self.N) / (self.c1 - self.N)
-#            (self.c1 * self.N * self.N - self.N) - \
         self.s_w = s
 
     def _get_Cs_r(self):
@@ -346,6 +350,7 @@ class z_r(object):
         self.Cs_r = Cs_r
         self.zeta = zeta
         self.Vtrans = Vtrans
+
 
     def __getitem__(self, key):
 
@@ -412,12 +417,13 @@ class z_w(object):
 
         ti = zeta.shape[0]
         z_w = np.empty((ti, self.Np) + self.h.shape, 'd')
+
         if self.Vtrans == 1:
             for n in range(ti):
                 for  k in range(self.Np):
                     z0 = self.hc * self.s_w[k] + (self.h - self.hc) * self.Cs_w[k]
                     z_w[n,k,:] = z0 + zeta[n,:] * (1.0 + z0 / self.h)
-        elif self.Vtrans == 2 or self.Vtrans == 4:
+        elif self.Vtrans == 2 or self.Vtrans == 4 or self.Vtrans == 5:
             for n in range(ti):
                 for  k in range(self.Np):
                     z0 = (self.hc * self.s_w[k] + self.h * self.Cs_w[k]) / \

--- a/pycnal/pycnal/vgrid.py
+++ b/pycnal/pycnal/vgrid.py
@@ -290,13 +290,6 @@ class s_coordinate_5(s_coordinate):
         self.z_w = z_w(self.h, self.hc, self.Np, self.s_w, self.Cs_w, self.zeta, self.Vtrans)
 
     def _get_s_rho(self):
-##        jgp replace
-#        lev = np.arange(1,self.N+1,1)
-#        s = -(lev * lev - 2 * lev * self.N + lev + self.N * self.N - self.N) / \
-#            (self.N * self.N - self.N) - \
-#            0.01 * (lev * lev - lev * self.N) / (self.c1 - self.N)
-#        self.s_rho = s
-##        jgp new section follows
         lev = np.arange(1, self.N+1) - .5
         self.s_rho = -(lev * lev - 2 * lev * self.N + lev + self.N * self.N - self.N) / \
             (1.0 * self.N * self.N - self.N) - \

--- a/pycnal_toolbox/pycnal_toolbox/remapping.py
+++ b/pycnal_toolbox/pycnal_toolbox/remapping.py
@@ -53,6 +53,7 @@ def remapping(varname, srcfile, wts_files, srcgrd, dstgrd, \
     srcgrdz = pycnal.grid.ROMS_Grid(srcgrd.name+'_Z', srcgrd.hgrid, src_zcoord)
     dstgrdz = pycnal.grid.ROMS_Grid(dstgrd.name+'_Z', dstgrd.hgrid, dst_zcoord)
 
+
     # varname argument
     if type(varname).__name__ == 'list':
         nvar = len(varname)
@@ -229,6 +230,13 @@ def remapping(varname, srcfile, wts_files, srcgrd, dstgrd, \
                                      Cpos=Cpos, spval=spval, flood=False)
                 else:
                     dst_var = dst_varz
+
+# jgp add
+                if varname[nv] == 'u':
+                    dst_u = dst_var
+                if varname[nv] == 'v':
+                    dst_v = dst_var
+# jgp end
 
                 # write data in destination file
                 print('write data in destination file')

--- a/pycnal_toolbox/pycnal_toolbox/remapping.py
+++ b/pycnal_toolbox/pycnal_toolbox/remapping.py
@@ -215,13 +215,10 @@ def remapping(varname, srcfile, wts_files, srcgrd, dstgrd, \
                 else:
                     src_varz = src_var[nt,jjrange[0]:jjrange[1],iirange[0]:iirange[1]]
 
-#                print datetime.datetime.now()
                 # horizontal interpolation using scrip weights
                 print('horizontal interpolation using scrip weights')
                 dst_varz = pycnal.remapping.remap(src_varz, wts_file, \
                                                   spval=spval)
-
-#                print datetime.datetime.now()
 
                 if ndim == 3:
                     # vertical interpolation from standard z level to sigma
@@ -231,12 +228,10 @@ def remapping(varname, srcfile, wts_files, srcgrd, dstgrd, \
                 else:
                     dst_var = dst_varz
 
-# jgp add
                 if varname[nv] == 'u':
                     dst_u = dst_var
                 if varname[nv] == 'v':
                     dst_v = dst_var
-# jgp end
 
                 # write data in destination file
                 print('write data in destination file')


### PR DESCRIPTION
I found vstretching=5 to work when creating an IC file or a BC file from HYCOM source data, but vstretching=5 didn't work when the source data came from another ROMS file.

pycnal/vgrid.py
The code for s_rho was identical to the code for s_w so had to be changed.

pycnal_toolbox/remapping.py
mods fix problem with ubar and vbar